### PR TITLE
feat: add high dpi support

### DIFF
--- a/example/main.zig
+++ b/example/main.zig
@@ -10,6 +10,8 @@ pub fn main() !void {
     var tray_instance = tray.Tray{};
     try tray_instance.init(
         allocator,
+        // enable high dp support, default is true
+        null,
         try tray.createIconFromFile("icon.ico"),
         &first_layer_menu,
         onPopupClick,

--- a/src/lib/windows.zig
+++ b/src/lib/windows.zig
@@ -350,3 +350,15 @@ pub extern "user32" fn LookupIconIdFromDirectoryEx(
     cyDesired: c_int,
     Flags: std.os.windows.UINT,
 ) callconv(std.os.windows.WINAPI) c_int;
+
+pub const DPI_AWARENESS_CONTEXT = isize;
+
+pub const DPI_AWARENESS_CONTEXT_UNAWARE: DPI_AWARENESS_CONTEXT = -1;
+pub const DPI_AWARENESS_CONTEXT_SYSTEM_AWARE: DPI_AWARENESS_CONTEXT = -2;
+pub const DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE: DPI_AWARENESS_CONTEXT = -3;
+pub const DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2: DPI_AWARENESS_CONTEXT = -4;
+pub const DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED: DPI_AWARENESS_CONTEXT = -5;
+
+pub extern "user32" fn SetProcessDpiAwarenessContext(
+    value: DPI_AWARENESS_CONTEXT,
+) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;


### PR DESCRIPTION
more info: [MicroSoft Docs](https://learn.microsoft.com/en-us/windows/win32/hidpi/setting-the-default-dpi-awareness-for-a-process)

The following are screenshots without high dpi support and with high dpi support enabled:

>My thinkpad is 3k resolution

disable high-dpi support:

![屏幕截图 2024-06-19 194344](https://github.com/star-tek-mb/zig-tray/assets/41784264/ef0e15ac-f3ac-41ad-bc20-a7a40eb496ab)

enable high-dpi support:
![屏幕截图 2024-06-19 194513](https://github.com/star-tek-mb/zig-tray/assets/41784264/aaa2ed2a-dd78-4d8e-bb84-3027f0f0dde4)
