### PR TITLE
chore!: support Zig 0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ zig-tray is a library for creating tray applications. Supports tray and notifica
 
 ## Installation
 
-### Zig `0.12` \ `0.13.0`
+zig-tray uses Zig 0.14.0.
 
 1. Add to `build.zig.zon`
 
@@ -34,13 +34,13 @@ Add this:
 ```zig
 // To standardize development, maybe you should use `lazyDependency()` instead of `dependency()`
 // more info to see: https://ziglang.org/download/0.12.0/release-notes.html#toc-Lazy-Dependencies
-const zig_tray = b.dependency("zig-tray", .{
+const zig_tray = b.dependency("zig_tray", .{
     .target = target,
     .optimize = optimize,
 });
 
 // add module
-exe.root_module.addImport("zig-tray", zig_tray.module("tray"));
+exe_mod.addImport("zig-tray", zig_tray.module("tray"));
 ```
 
 ## Example

--- a/build.zig
+++ b/build.zig
@@ -7,31 +7,27 @@ pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
 
     // export zig-tray module
-    const zigTray = switch (target.result.os.tag) {
+    const zig_tray = switch (target.result.os.tag) {
         .windows => b.addModule("tray", .{
             .root_source_file = b.path("src/tray_windows.zig"),
+            .target = target,
+            .optimize = optimize,
         }),
         else => @panic("Unsupported platform, now only support windows"),
     };
 
     // generate docs
-    generateDocs(b, target, optimize);
+    generateDocs(b, zig_tray);
 
     // build example
-    example(b, target, optimize, zigTray);
+    example(b, target, optimize, zig_tray);
 }
 
 /// for generate docs
-fn generateDocs(
-    b: *std.Build,
-    target: std.Build.ResolvedTarget,
-    optimize: std.builtin.OptimizeMode,
-) void {
+fn generateDocs(b: *std.Build, module: *std.Build.Module) void {
     const zig_tray_obj = b.addObject(.{
         .name = "zig-tray-obj",
-        .root_source_file = b.path("src/tray_windows.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = module,
     });
 
     const docs_step = b.step("docs", "Generate docs");
@@ -50,12 +46,16 @@ fn example(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builti
     if (target.result.os.tag != .windows)
         return;
 
-    // build example
-    const exe = b.addExecutable(.{
-        .name = "zig-tray",
+    const exe_mod = b.createModule(.{
         .root_source_file = b.path("example/main.zig"),
         .target = target,
         .optimize = optimize,
+    });
+
+    // build example
+    const exe = b.addExecutable(.{
+        .name = "zig-tray",
+        .root_module = exe_mod,
     });
 
     exe.root_module.addImport("tray", module);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,7 +1,8 @@
 .{
-    .name = "zig-tray",
+    .name = .zig_tray,
     .version = "0.0.1",
-    .minimum_zig_version = "0.12.0",
+    .fingerprint = 0xf392474b7e22f65,
+    .minimum_zig_version = "0.14.0",
     .dependencies = .{},
     .paths = .{
         "src",

--- a/example/main.zig
+++ b/example/main.zig
@@ -1,11 +1,11 @@
 const std = @import("std");
 const tray = @import("tray");
 
-var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+var debug_allocator: std.heap.DebugAllocator(.{}) = .init;
 
 pub fn main() !void {
-    const allocator = gpa.allocator();
-    defer if (gpa.deinit() == .leak) @panic("TEST FAIL");
+    const allocator = debug_allocator.allocator();
+    defer if (debug_allocator.deinit() == .leak) @panic("TEST FAIL");
 
     var tray_instance = tray.Tray{};
     try tray_instance.init(

--- a/src/lib/windows.zig
+++ b/src/lib/windows.zig
@@ -7,7 +7,7 @@ pub const WNDPROC = *const fn (
     uMsg: std.os.windows.UINT,
     wParam: std.os.windows.WPARAM,
     lParam: std.os.windows.LPARAM,
-) callconv(std.os.windows.WINAPI) std.os.windows.LRESULT;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.LRESULT;
 
 pub const MSG = extern struct {
     hWnd: ?std.os.windows.HWND,
@@ -47,24 +47,24 @@ pub extern "user32" fn CreateWindowExA(
     hMenu: ?std.os.windows.HMENU,
     hInstance: std.os.windows.HINSTANCE,
     lpParam: ?std.os.windows.LPVOID,
-) callconv(std.os.windows.WINAPI) ?std.os.windows.HWND;
+) callconv(std.builtin.CallingConvention.winapi) ?std.os.windows.HWND;
 
 pub extern "user32" fn RegisterClassExA(
     *const WNDCLASSEXA,
-) callconv(std.os.windows.WINAPI) std.os.windows.ATOM;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.ATOM;
 
 pub extern "user32" fn SetWindowLongPtrA(
     hWnd: std.os.windows.HWND,
     nIndex: i32,
     dwNewLong: std.os.windows.LONG_PTR,
-) callconv(std.os.windows.WINAPI) std.os.windows.LONG_PTR;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.LONG_PTR;
 
 pub extern "user32" fn GetMessageA(
     lpMsg: *MSG,
     hWnd: ?std.os.windows.HWND,
     wMsgFilterMin: std.os.windows.UINT,
     wMsgFilterMax: std.os.windows.UINT,
-) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
 
 pub extern "user32" fn PeekMessageA(
     lpMsg: *MSG,
@@ -72,53 +72,53 @@ pub extern "user32" fn PeekMessageA(
     wMsgFilterMin: std.os.windows.UINT,
     wMsgFilterMax: std.os.windows.UINT,
     wRemoveMsg: std.os.windows.UINT,
-) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
 
 pub extern "user32" fn TranslateMessage(
     lpMsg: *const MSG,
-) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
 
 pub extern "user32" fn DispatchMessageA(
     lpMsg: *const MSG,
-) callconv(std.os.windows.WINAPI) std.os.windows.LRESULT;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.LRESULT;
 
 pub extern "user32" fn UpdateWindow(
     hWnd: std.os.windows.HWND,
-) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
 
 pub extern "user32" fn PostQuitMessage(
     nExitCode: i32,
-) callconv(std.os.windows.WINAPI) void;
+) callconv(std.builtin.CallingConvention.winapi) void;
 
 pub extern "user32" fn UnregisterClassA(
     lpClassName: [*:0]const u8,
     hInstance: std.os.windows.HINSTANCE,
-) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
 
 pub extern "user32" fn GetWindowLongPtrA(
     hWnd: std.os.windows.HWND,
     nIndex: i32,
-) callconv(std.os.windows.WINAPI) std.os.windows.LONG_PTR;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.LONG_PTR;
 
 pub extern "user32" fn DefWindowProcA(
     hWnd: std.os.windows.HWND,
     Msg: std.os.windows.UINT,
     wParam: std.os.windows.WPARAM,
     lParam: std.os.windows.LPARAM,
-) callconv(std.os.windows.WINAPI) std.os.windows.LRESULT;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.LRESULT;
 
 pub extern "user32" fn DestroyWindow(
     hWnd: std.os.windows.HWND,
-) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
 
 pub extern "user32" fn GetDC(
     hWnd: ?std.os.windows.HWND,
-) callconv(std.os.windows.WINAPI) ?std.os.windows.HDC;
+) callconv(std.builtin.CallingConvention.winapi) ?std.os.windows.HDC;
 
 pub extern "user32" fn ReleaseDC(
     hWnd: ?std.os.windows.HWND,
     hDC: std.os.windows.HDC,
-) callconv(std.os.windows.WINAPI) i32;
+) callconv(std.builtin.CallingConvention.winapi) i32;
 
 pub const PM_REMOVE = 0x0001;
 pub const WM_DESTROY = 0x0002;
@@ -239,11 +239,11 @@ pub const ICONINFO = extern struct {
 
 pub extern "user32" fn GetCursorPos(
     lpPoint: [*c]std.os.windows.POINT,
-) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
 
 pub extern "user32" fn SetForegroundWindow(
     hWnd: std.os.windows.HWND,
-) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
 
 pub extern "user32" fn TrackPopupMenu(
     hMenu: std.os.windows.HMENU,
@@ -253,16 +253,16 @@ pub extern "user32" fn TrackPopupMenu(
     nReserved: i32,
     hWnd: std.os.windows.HWND,
     prcRect: [*c]const std.os.windows.RECT,
-) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
 
 pub extern "user32" fn SendMessageA(
     hWnd: std.os.windows.HWND,
     uMsg: std.os.windows.UINT,
     wParam: std.os.windows.WPARAM,
     lParam: std.os.windows.LPARAM,
-) callconv(std.os.windows.WINAPI) std.os.windows.LRESULT;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.LRESULT;
 
-pub extern "user32" fn CreatePopupMenu() callconv(std.os.windows.WINAPI) std.os.windows.HMENU;
+pub extern "user32" fn CreatePopupMenu() callconv(std.builtin.CallingConvention.winapi) std.os.windows.HMENU;
 
 pub extern "user32" fn InsertMenuW(
     hMenu: std.os.windows.HMENU,
@@ -270,38 +270,38 @@ pub extern "user32" fn InsertMenuW(
     uFlags: std.os.windows.UINT,
     uIDNewItem: std.os.windows.ULONGLONG,
     lpNewItem: ?std.os.windows.LPCWSTR,
-) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
 
 pub extern "user32" fn InsertMenuItemW(
     hMenu: std.os.windows.HMENU,
     item: std.os.windows.UINT,
     fByPosition: std.os.windows.BOOL,
     lpmi: [*c]MENUITEMINFOW,
-) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
 
 pub extern "user32" fn DestroyMenu(
     hMenu: std.os.windows.HMENU,
-) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
 
 pub extern "user32" fn DestroyIcon(
     hIcon: std.os.windows.HICON,
-) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
 
 pub extern "user32" fn GetMenuItemInfoW(
     hMenu: std.os.windows.HMENU,
     item: std.os.windows.UINT,
     fByPosition: std.os.windows.BOOL,
     lpmii: [*c]MENUITEMINFOW,
-) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
 
 pub extern "user32" fn CreateIconIndirect(
     piconinfo: [*c]ICONINFO,
-) callconv(std.os.windows.WINAPI) std.os.windows.HICON;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.HICON;
 
 pub extern "shell32" fn Shell_NotifyIconW(
     dwMessage: std.os.windows.DWORD,
     lpData: [*c]NOTIFYICONDATAW,
-) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
 
 pub extern "shell32" fn ExtractIconExA(
     lpszFile: std.os.windows.LPCSTR,
@@ -309,7 +309,7 @@ pub extern "shell32" fn ExtractIconExA(
     phiconLarge: [*c]std.os.windows.HICON,
     phiconSmall: [*c]std.os.windows.HICON,
     nIcons: std.os.windows.UINT,
-) callconv(std.os.windows.WINAPI) std.os.windows.UINT;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.UINT;
 
 // TODO: pbmi is type of const BITMAPINFO*
 pub extern "gdi32" fn CreateDIBSection(
@@ -319,7 +319,7 @@ pub extern "gdi32" fn CreateDIBSection(
     ppvBits: [*c][*c]u8,
     hSection: ?std.os.windows.HANDLE,
     offset: std.os.windows.DWORD,
-) callconv(std.os.windows.WINAPI) ?HBITMAP;
+) callconv(std.builtin.CallingConvention.winapi) ?HBITMAP;
 
 pub extern "gdi32" fn CreateBitmap(
     nWidth: i32,
@@ -327,11 +327,11 @@ pub extern "gdi32" fn CreateBitmap(
     nPlanes: std.os.windows.UINT,
     nBitCount: std.os.windows.UINT,
     lpBits: ?*const anyopaque,
-) callconv(std.os.windows.WINAPI) ?HBITMAP;
+) callconv(std.builtin.CallingConvention.winapi) ?HBITMAP;
 
 pub extern "gdi32" fn DeleteObject(
     ho: HBITMAP,
-) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;
 
 pub extern "user32" fn CreateIconFromResourceEx(
     presbits: [*c]const u8,
@@ -341,7 +341,7 @@ pub extern "user32" fn CreateIconFromResourceEx(
     cxDesired: c_int,
     cyDesired: c_int,
     Flags: std.os.windows.UINT,
-) callconv(std.os.windows.WINAPI) ?std.os.windows.HICON;
+) callconv(std.builtin.CallingConvention.winapi) ?std.os.windows.HICON;
 
 pub extern "user32" fn LookupIconIdFromDirectoryEx(
     presbits: [*c]const u8,
@@ -349,7 +349,7 @@ pub extern "user32" fn LookupIconIdFromDirectoryEx(
     cxDesired: c_int,
     cyDesired: c_int,
     Flags: std.os.windows.UINT,
-) callconv(std.os.windows.WINAPI) c_int;
+) callconv(std.builtin.CallingConvention.winapi) c_int;
 
 pub const DPI_AWARENESS_CONTEXT = isize;
 
@@ -361,4 +361,4 @@ pub const DPI_AWARENESS_CONTEXT_UNAWARE_GDISCALED: DPI_AWARENESS_CONTEXT = -5;
 
 pub extern "user32" fn SetProcessDpiAwarenessContext(
     value: DPI_AWARENESS_CONTEXT,
-) callconv(std.os.windows.WINAPI) std.os.windows.BOOL;
+) callconv(std.builtin.CallingConvention.winapi) std.os.windows.BOOL;

--- a/src/tray_windows.zig
+++ b/src/tray_windows.zig
@@ -342,7 +342,7 @@ const BITMAPV5HEADER = lib_win.BITMAPV5HEADER;
 
 const ICONINFO = lib_win.ICONINFO;
 
-fn WndProc(hwnd: windows.HWND, uMsg: windows.UINT, wParam: windows.WPARAM, lParam: windows.LPARAM) callconv(windows.WINAPI) windows.LRESULT {
+fn WndProc(hwnd: windows.HWND, uMsg: windows.UINT, wParam: windows.WPARAM, lParam: windows.LPARAM) callconv(std.builtin.CallingConvention.winapi) windows.LRESULT {
     const tray_pointer = lib_win.GetWindowLongPtrA(hwnd, 0);
     if (tray_pointer == 0) {
         return lib_win.DefWindowProcA(hwnd, uMsg, wParam, lParam);


### PR DESCRIPTION
This PR updates `build.zig.zon` to support the current stable version of Zig and removes the usages of the following deprecated APIs.

- `std.heap.GeneralPurposeAllocator`
- `std.os.windows.WINAPI`
- `std.Build.ExecutableOptions.{root_source_file,target,optimize}`